### PR TITLE
Epics cleanup

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,14 @@
 Release notes for the SLAC LCLS-II HPS MPS Link Node
 
 ## Releases:
+* __l2MpsLN-R3-7-0__: 2020-05-20 J. Mock
+  * Upgrade iocAdmin to version R3.1.16-1.3.0 to deal with timezone PV problem
+  * Add seq version R2.2.4-1.2 to RELEASE. Load devSeqCar.dbd and lib devSeqCar seq pv 
+      in the src/Makefile to load the devSeqCar.db file for Accelerator network screens
+  * Change the macro for autosave from ${L2MPS_PREFIX} to ${IOC_NAME} to conform with
+      Accelerator Network common screens.  Changed in link_node.cmd and application_node.cmd
+  * Comment in TPR Pattern load in application_node.cmd - this was a mistake in R3-6-0
+  * Add sioc-b084-mp03 to run on shm-b084-hp04 slot 2 on cpu-b084-hp03 - BLEN/BCM test stand
 * __l2MpsLN-R3-6-0__: 2020-05-14 J. Mock
   * Add support for PV inputs to MPS Digital APP (i.e. soft inputs) (#37, #38)
     * Update l2Mps to version R3.4.1

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -15,7 +15,7 @@
 # Don't set your version to anything such as "test" that
 # could match a directory name.
 # ==========================================================
-IOCADMIN_MODULE_VERSION=R3.1.16-1.2.0
+IOCADMIN_MODULE_VERSION=R3.1.16-1.3.0
 AUTOSAVE_MODULE_VERSION=R5.8-2.1.0
 ASYN_MODULE_VERSION=R4.32-1.0.0
 YAMLLOADER_MODULE_VERSION=R2.1.0
@@ -27,6 +27,7 @@ BSACORE_MODULE_VERSION=R1.5.3
 TIMINGAPI_MODULE_VERSION=R0.6
 TPRPATTERN_MODULE_VERSION=R1.4.0
 EVRCLIENT_MODULE_VERSION=R1.5.0
+SEQ_MODULE_VERSION=R2.2.4-1.2
 
 # ==========================================================
 # Define module paths using pattern
@@ -46,6 +47,7 @@ BSACORE=$(EPICS_MODULES)/BsaCore/$(BSACORE_MODULE_VERSION)
 TIMINGAPI=$(EPICS_MODULES)/timingApi/$(TIMINGAPI_MODULE_VERSION)
 TPRPATTERN=$(EPICS_MODULES)/tprPattern/$(TPRPATTERN_MODULE_VERSION)
 EVRCLIENT=$(EPICS_MODULES)/evrClient/$(EVRCLIENT_MODULE_VERSION)
+SEQ=$(EPICS_MODULES)/seq/$(SEQ_MODULE_VERSION)
 
 # =====================================================================
 # Set EPICS_BASE last so it appears last in the DB, DBD, INCLUDE, and LIB search paths

--- a/iocBoot/common/application_node.cmd
+++ b/iocBoot/common/application_node.cmd
@@ -97,7 +97,7 @@ tprTriggerAsynDriverConfigure("${TPRTRIGGER_PORT}", "mmio/AmcCarrierCore")
 #    Port name,                 # The name given to this port driver
 #    Root path,                 # Root path to the AmcCarrierCore register area
 #    Stream name)               # Name of the timing stream
-#tprPatternAsynDriverConfigure("${TPRPATTERN_PORT}", "mmio/AmcCarrierCore", "tstream")
+tprPatternAsynDriverConfigure("${TPRPATTERN_PORT}", "mmio/AmcCarrierCore", "tstream")
 
 # ==========================================
 # Load application specific configurations
@@ -125,7 +125,7 @@ dbLoadRecords("db/mpsAN.db", "P=${L2MPS_PREFIX}, PORT=${YCPSWASYN_PORT}")
 dbLoadRecords("db/tprTrig.db", "PORT=${TPRTRIGGER_PORT},LOCA=${LOCATION},IOC_UNIT=MP${LOCATION_INDEX},INST=${CARD_INDEX}")
 
 # tprPattern database
-#dbLoadRecords("db/tprPattern.db", "PORT=${TPRPATTERN_PORT},LOCA=${LOCATION},IOC_UNIT=MP${LOCATION_INDEX},INST=${CARD_INDEX}")
+dbLoadRecords("db/tprPattern.db", "PORT=${TPRPATTERN_PORT},LOCA=${LOCATION},IOC_UNIT=MP${LOCATION_INDEX},INST=${CARD_INDEX}")
 
 # Save/load configuration database
 dbLoadRecords("db/saveLoadConfig.db", "P=${L2MPS_PREFIX}, PORT=${YCPSWASYN_PORT}")
@@ -143,7 +143,11 @@ dbLoadRecords("db/iocRelease.db","IOC=${IOC}")
 
 # *******************************************
 # **** Load database for autosave status ****
-dbLoadRecords("db/save_restoreStatus.db", "P=${L2MPS_PREFIX}:")
+dbLoadRecords("db/save_restoreStatus.db", "P=${IOC_NAME}:")
+
+# *******************************************
+# **** Load database for seqCar status ****
+dbLoadRecords("db/devSeqCar.db"    ,"SIOC=${IOC_NAME}")
 
 # ===========================================
 #           SETUP AUTOSAVE/RESTORE
@@ -168,7 +172,7 @@ set_savefile_path("${IOC_DATA}/${IOC}/autosave")
 # Prefix that is use to update save/restore status database
 # records
 save_restoreSet_UseStatusPVs(1)
-save_restoreSet_status_prefix("${L2MPS_PREFIX}:")
+save_restoreSet_status_prefix("${IOC_NAME}:")
 
 ## Restore datasets
 set_pass0_restoreFile("info_settings.sav")

--- a/iocBoot/common/link_node.cmd
+++ b/iocBoot/common/link_node.cmd
@@ -144,7 +144,11 @@ dbLoadRecords("db/iocRelease.db","IOC=${IOC}")
 
 # *******************************************
 # **** Load database for autosave status ****
-dbLoadRecords("db/save_restoreStatus.db", "P=${L2MPS_PREFIX}:")
+dbLoadRecords("db/save_restoreStatus.db", "P=${IOC_NAME}:")
+
+# *******************************************
+# **** Load database for seqCar status ****
+dbLoadRecords("db/devSeqCar.db"    ,"SIOC=${IOC_NAME}")
 
 # ===========================================
 #           SETUP AUTOSAVE/RESTORE
@@ -169,7 +173,7 @@ set_savefile_path("${IOC_DATA}/${IOC}/autosave")
 # Prefix that is use to update save/restore status database
 # records
 save_restoreSet_UseStatusPVs(1)
-save_restoreSet_status_prefix("${L2MPS_PREFIX}:")
+save_restoreSet_status_prefix("${IOC_NAME}:")
 
 ## Restore datasets
 set_pass0_restoreFile("info_settings.sav")

--- a/iocBoot/sioc-b084-mp03/Makefile
+++ b/iocBoot/sioc-b084-mp03/Makefile
@@ -1,0 +1,5 @@
+TOP = ../..
+include $(TOP)/configure/CONFIG
+ARCH = $(EPICS_HOST_ARCH)
+TARGETS = envPaths
+include $(TOP)/configure/RULES.ioc

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/02/config.yaml
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/02/config.yaml
@@ -1,0 +1,40 @@
+# Analog application AppID
+- mmio:
+  - AmcCarrierCore:
+    - AppMps:
+      - AppMpsRegBase:
+        - mpsAppId: !<value> 1
+# Disable all thresholds
+- mmio:
+  - AmcCarrierCore:
+    - AppMps:
+      - AppMpsRegAppCh:
+        - channel:
+          - idleEn: !<value> 0x0
+          - lcls1Thr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - stdThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - idleThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - altThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+# Digital application AppID
+- mmio:
+  - AppTop:
+    - AppCore:
+      - MpsLinkNodeCore:
+        - MpsDigitalMessage:
+          - AppId: !<value> 2

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/02/mps.db
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/02/mps.db
@@ -1,0 +1,2146 @@
+record(longin, "MPLN:B084:MP03:1:APP_ID") {
+    field(DESC, "Application ID")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)APP_ID")
+}
+record(longin, "MPLN:B084:MP03:1:BYTE_COUNT") {
+    field(DESC, "Number of bytes in MPS message")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)BYTE_COUNT")
+}
+record(longin, "MPLN:B084:MP03:1:ROLL_OVER_EN") {
+    field(DESC, "Status Counter Roll Over Enable")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)ROLL_OVER_EN")
+}
+record(longin, "MPLN:B084:MP03:1:TX_LINK_UP_CNT") {
+    field(DESC, "MPS TX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)TX_LINK_UP_CNT")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_0") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_0")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_1") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_1")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_2") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_2")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_3") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_3")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_4") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_4")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_5") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_5")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_6") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_6")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_7") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_7")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_8") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_8")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_9") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_9")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_10") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_10")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_11") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_11")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_12") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_12")
+}
+record(longin, "MPLN:B084:MP03:1:RX_LINK_UP_CNT_13") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_13")
+}
+record(longin, "MPLN:B084:MP03:1:TX_PKT_SENT_CNT") {
+    field(DESC, "MPS TX Packet Sent Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)TX_PKT_SENT_CNT")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_0") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_0")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_1") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_1")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_2") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_2")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_3") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_3")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_4") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_4")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_5") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_5")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_6") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_6")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_7") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_7")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_8") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_8")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_9") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_9")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_10") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_10")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_11") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_11")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_12") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_12")
+}
+record(longin, "MPLN:B084:MP03:1:RX_PKT_RCV_CNT_13") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_13")
+}
+record(longin, "MPLN:B084:MP03:1:MSG_CNT") {
+    field(DESC, "Mps message counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)MSG_CNT")
+}
+record(longin, "MPLN:B084:MP03:1:LAST_MSG_APP_ID") {
+    field(DESC, "Mps last message App ID")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_APPID")
+}
+record(longin, "MPLN:B084:MP03:1:LAST_MSG_TMSTMP") {
+    field(DESC, "Mps last message timestamp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_TMSTMP")
+}
+record(longin, "MPLN:B084:MP03:1:LAST_MSG_BYTE_0") {
+    field(DESC, "Mps last message byte 0")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_0")
+}
+record(longin, "MPLN:B084:MP03:1:LAST_MSG_BYTE_1") {
+    field(DESC, "Mps last message byte 1")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_1")
+}
+record(longin, "MPLN:B084:MP03:1:LAST_MSG_BYTE_2") {
+    field(DESC, "Mps last message byte 2")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_2")
+}
+record(longin, "MPLN:B084:MP03:1:LAST_MSG_BYTE_3") {
+    field(DESC, "Mps last message byte 3")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_3")
+}
+record(longin, "MPLN:B084:MP03:1:LAST_MSG_BYTE_4") {
+    field(DESC, "Mps last message byte 4")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_4")
+}
+record(longin, "MPLN:B084:MP03:1:LAST_MSG_BYTE_5") {
+    field(DESC, "Mps last message byte 5")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_5")
+}
+record(bi, "MPLN:B084:MP03:1:DIGITAL_EN") {
+    field(DESC, "Application generates digital messages")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)DIGITAL_EN")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:B084:MP03:1:MPS_SLOT") {
+    field(DESC, "MPS_SLOT_G")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)MPS_SLOT")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:B084:MP03:1:PLL_LOCKED") {
+    field(DESC, "MPS PLL Lock Status")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)PLL_LOCKED")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:B084:MP03:1:TX_LINK_UP") {
+    field(DESC, "MPS TX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)TX_LINK_UP")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_0") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_0")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_1") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_1")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_2") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_2")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_3") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_3")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_4") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_4")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_5") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_5")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_6") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_6")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_7") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_7")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_8") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_8")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_9") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_9")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_10") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_10")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_11") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_11")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_12") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_12")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:RX_LINK_UP_13") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_13")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:B084:MP03:1:LAST_MSG_LC1_EN") {
+    field(DESC, "LCLS flag in the last message")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)LAST_MSG_LCLS")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bo, "MPLN:B084:MP03:1:SALT_RST_CNT") {
+    field(DESC, "Reset all the SALT status counters")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)SALT_RST_CNT")
+    field(ZNAM, "")
+    field(ONAM, "")
+}
+
+record(bo, "MPLN:B084:MP03:1:SALT_RST_PLL") {
+    field(DESC, "Reset the PLL")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)SALT_RST_PLL")
+    field(ZNAM, "")
+    field(ONAM, "")
+}
+
+record(longout, "MPLN:B084:MP03:1:BEAM_DEST_MASK") {
+    field(DESC, "One bit per dest for BPM or kicker")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)BEAM_DEST_MASK")
+}
+
+record(longin, "MPLN:B084:MP03:1:BEAM_DEST_MASK_RBV") {
+    field(DESC, "One bit per dest for BPM or kicker")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)BEAM_DEST_MASK")
+}
+
+record(longout, "MPLN:B084:MP03:1:ALT_DEST_MASK") {
+    field(DESC, "One bit per dest for alt table")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)ALT_DEST_MASK")
+}
+
+record(longin, "MPLN:B084:MP03:1:ALT_DEST_MASK_RBV") {
+    field(DESC, "One bit per dest for alt table")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)ALT_DEST_MASK")
+}
+
+record(longout, "MPLN:B084:MP03:1:MPS_VER") {
+    field(DESC, "MPS version")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)MPS_VER")
+}
+
+record(longin, "MPLN:B084:MP03:1:MPS_VER_RBV") {
+    field(DESC, "MPS version")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)MPS_VER")
+}
+
+record(bo, "MPLN:B084:MP03:1:MPS_EN") {
+    field(DESC, "MPS Enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)MPS_EN")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "MPLN:B084:MP03:1:MPS_EN_RBV") {
+    field(DESC, "MPS Enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)MPS_EN")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bo, "MPLN:B084:MP03:1:LC1_MODE") {
+    field(DESC, "LCLS operation mode")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)LCLS1_MODE")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "MPLN:B084:MP03:1:LC1_MODE_RBV") {
+    field(DESC, "LCLS operation mode")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)LCLS1_MODE")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(waveform, "MPLN:B084:MP03:1:APP_TYPE") {
+    field(DESC,    "Application type")
+    field(PINI,    "NO")
+    field(SCAN,    "I/O Intr")
+    field(DTYP,    "asynOctetRead")
+    field(NELM,    "40")
+    field(FTVL,    "CHAR")
+    field(INP,     "@asyn($(PORT,undefined),2)APP_TYPE")
+}
+
+record(ao,      "SOLN:B084:212:I0_FWSLO") {
+    field(DESC, "Scale factor")
+    field(EGU,  "A/raw")
+    field(PREC, "4")
+    field(SCAN, "Passive")
+    field(PHAS, "0")
+    field(PINI, "YES")
+    field(VAL,  "555.86e-6")
+}
+
+record(ao,      "SOLN:B084:212:I0_FWOFF") {
+    field(DESC, "Scale factor")
+    field(EGU,  "raw")
+    field(PREC, "4")
+    field(SCAN, "Passive")
+    field(PHAS, "0")
+    field(PINI, "YES")
+    field(VAL,  "32768")
+}
+
+record(longin, "SOLN:B084:212:I0_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRNUM_00")
+}
+record(longin, "SOLN:B084:212:I0_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRCNT_00")
+}
+record(longin, "SOLN:B084:212:I0_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_BYTEMAP_00")
+}
+record(bo, "SOLN:B084:212:I0_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_IDLEEN_00")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "SOLN:B084:212:I0_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_IDLEEN_00")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "SOLN:B084:212:I0_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_ALTEN_00")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "SOLN:B084:212:I0_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_LCLS1EN_00")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "SOLN:B084:212:I0_T0_LC1_L") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMIN_0000")
+}
+
+record(ai,  "SOLN:B084:212:I0_T0_LC1_L_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMIN_0000")
+}
+
+record(ao, "SOLN:B084:212:I0_T0_LC1_H") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMAX_0000")
+}
+
+record(ai,  "SOLN:B084:212:I0_T0_LC1_H_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAX_0000")
+}
+
+record(bo, "SOLN:B084:212:I0_T0_LC1_L_EN") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_0000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "SOLN:B084:212:I0_T0_LC1_L_EN_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_0000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "SOLN:B084:212:I0_T0_LC1_H_EN") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_0000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "SOLN:B084:212:I0_T0_LC1_H_EN_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_0000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "SOLN:B084:212:I0_T0_IDL_L") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMIN_0010")
+}
+
+record(ai,  "SOLN:B084:212:I0_T0_IDL_L_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMIN_0010")
+}
+
+record(ao, "SOLN:B084:212:I0_T0_IDL_H") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMAX_0010")
+}
+
+record(ai,  "SOLN:B084:212:I0_T0_IDL_H_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAX_0010")
+}
+
+record(bo, "SOLN:B084:212:I0_T0_IDL_L_EN") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_0010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "SOLN:B084:212:I0_T0_IDL_L_EN_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_0010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "SOLN:B084:212:I0_T0_IDL_H_EN") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_0010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "SOLN:B084:212:I0_T0_IDL_H_EN_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_0010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(ao,      "SOLN:B084:212:I0_SS") {
+    field(DESC, "Scale slope factor")
+    field(SCAN, "1 second")
+    field(PHAS, "1")
+    field(PINI, "YES")
+    field(EGU,  "uA/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "SOLN:B084:212:I0_FWSLO")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),0)BLM_SCALESLOPE_00")
+}
+record(ai,      "SOLN:B084:212:I0_SS_RBV") {
+    field(DESC, "Scale slope factor (readback)")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "uA/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),0)BLM_SCALESLOPE_00")
+}
+record(ao,      "SOLN:B084:212:I0_SO") {
+    field(DESC, "Scale offset factor")
+    field(SCAN, "1 second")
+    field(PHAS, "1")
+    field(PINI, "YES")
+    field(EGU,  "raw")
+    field(PREC, "0")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "SOLN:B084:212:I0_FWOFF")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),0)BLM_SCALEOFFSET_00")
+}
+record(ai,      "SOLN:B084:212:I0_SO_RBV") {
+    field(DESC, "Scale offset factor (readback)")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "raw")
+    field(PREC, "0")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),0)BLM_SCALEOFFSET_00")
+}
+
+record(ao, "SOLN:B084:212:I0_T0_L") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMIN_0020")
+}
+
+record(ai,  "SOLN:B084:212:I0_T0_L_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMIN_0020")
+}
+
+record(longin, "SOLN:B084:212:I0_T0_L_RAW") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMINR_0020")
+}
+
+record(ao, "SOLN:B084:212:I0_T0_H") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMAX_0020")
+}
+
+record(ai,  "SOLN:B084:212:I0_T0_H_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAX_0020")
+}
+
+record(longin, "SOLN:B084:212:I0_T0_H_RAW") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAXR_0020")
+}
+
+record(bo, "SOLN:B084:212:I0_T0_L_EN") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_0020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "SOLN:B084:212:I0_T0_L_EN_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_0020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "SOLN:B084:212:I0_T0_H_EN") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_0020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "SOLN:B084:212:I0_T0_H_EN_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_0020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "SOLN:B084:212:I0_T0_ALT_L") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMIN_0030")
+}
+
+record(ai,  "SOLN:B084:212:I0_T0_ALT_L_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMIN_0030")
+}
+
+record(ao, "SOLN:B084:212:I0_T0_ALT_H") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMAX_0030")
+}
+
+record(ai,  "SOLN:B084:212:I0_T0_ALT_H_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAX_0030")
+}
+
+record(bo, "SOLN:B084:212:I0_T0_ALT_L_EN") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_0030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "SOLN:B084:212:I0_T0_ALT_L_EN_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_0030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "SOLN:B084:212:I0_T0_ALT_H_EN") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_0030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "SOLN:B084:212:I0_T0_ALT_H_EN_RBV") {
+    field(DESC, "SOL1B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_0030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(ao,      "SOLN:B084:823:I0_FWSLO") {
+    field(DESC, "Scale factor")
+    field(EGU,  "A/raw")
+    field(PREC, "4")
+    field(SCAN, "Passive")
+    field(PHAS, "0")
+    field(PINI, "YES")
+    field(VAL,  "555.86e-6")
+}
+
+record(ao,      "SOLN:B084:823:I0_FWOFF") {
+    field(DESC, "Scale factor")
+    field(EGU,  "raw")
+    field(PREC, "4")
+    field(SCAN, "Passive")
+    field(PHAS, "0")
+    field(PINI, "YES")
+    field(VAL,  "32768")
+}
+
+record(longin, "SOLN:B084:823:I0_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRNUM_10")
+}
+record(longin, "SOLN:B084:823:I0_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRCNT_10")
+}
+record(longin, "SOLN:B084:823:I0_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_BYTEMAP_10")
+}
+record(bo, "SOLN:B084:823:I0_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_IDLEEN_10")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "SOLN:B084:823:I0_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_IDLEEN_10")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "SOLN:B084:823:I0_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_ALTEN_10")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "SOLN:B084:823:I0_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_LCLS1EN_10")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "SOLN:B084:823:I0_T0_LC1_L") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMIN_1000")
+}
+
+record(ai,  "SOLN:B084:823:I0_T0_LC1_L_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMIN_1000")
+}
+
+record(ao, "SOLN:B084:823:I0_T0_LC1_H") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMAX_1000")
+}
+
+record(ai,  "SOLN:B084:823:I0_T0_LC1_H_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAX_1000")
+}
+
+record(bo, "SOLN:B084:823:I0_T0_LC1_L_EN") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_1000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "SOLN:B084:823:I0_T0_LC1_L_EN_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_1000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "SOLN:B084:823:I0_T0_LC1_H_EN") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_1000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "SOLN:B084:823:I0_T0_LC1_H_EN_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_1000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "SOLN:B084:823:I0_T0_IDL_L") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMIN_1010")
+}
+
+record(ai,  "SOLN:B084:823:I0_T0_IDL_L_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMIN_1010")
+}
+
+record(ao, "SOLN:B084:823:I0_T0_IDL_H") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMAX_1010")
+}
+
+record(ai,  "SOLN:B084:823:I0_T0_IDL_H_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAX_1010")
+}
+
+record(bo, "SOLN:B084:823:I0_T0_IDL_L_EN") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_1010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "SOLN:B084:823:I0_T0_IDL_L_EN_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_1010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "SOLN:B084:823:I0_T0_IDL_H_EN") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_1010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "SOLN:B084:823:I0_T0_IDL_H_EN_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_1010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(ao,      "SOLN:B084:823:I0_SS") {
+    field(DESC, "Scale slope factor")
+    field(SCAN, "1 second")
+    field(PHAS, "1")
+    field(PINI, "YES")
+    field(EGU,  "uA/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "SOLN:B084:823:I0_FWSLO")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),0)BLM_SCALESLOPE_10")
+}
+record(ai,      "SOLN:B084:823:I0_SS_RBV") {
+    field(DESC, "Scale slope factor (readback)")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "uA/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),0)BLM_SCALESLOPE_10")
+}
+record(ao,      "SOLN:B084:823:I0_SO") {
+    field(DESC, "Scale offset factor")
+    field(SCAN, "1 second")
+    field(PHAS, "1")
+    field(PINI, "YES")
+    field(EGU,  "raw")
+    field(PREC, "0")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "SOLN:B084:823:I0_FWOFF")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),0)BLM_SCALEOFFSET_10")
+}
+record(ai,      "SOLN:B084:823:I0_SO_RBV") {
+    field(DESC, "Scale offset factor (readback)")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "raw")
+    field(PREC, "0")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT),0)BLM_SCALEOFFSET_10")
+}
+
+record(ao, "SOLN:B084:823:I0_T0_L") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMIN_1020")
+}
+
+record(ai,  "SOLN:B084:823:I0_T0_L_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMIN_1020")
+}
+
+record(longin, "SOLN:B084:823:I0_T0_L_RAW") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMINR_1020")
+}
+
+record(ao, "SOLN:B084:823:I0_T0_H") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMAX_1020")
+}
+
+record(ai,  "SOLN:B084:823:I0_T0_H_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAX_1020")
+}
+
+record(longin, "SOLN:B084:823:I0_T0_H_RAW") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAXR_1020")
+}
+
+record(bo, "SOLN:B084:823:I0_T0_L_EN") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_1020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "SOLN:B084:823:I0_T0_L_EN_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_1020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "SOLN:B084:823:I0_T0_H_EN") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_1020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "SOLN:B084:823:I0_T0_H_EN_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_1020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "SOLN:B084:823:I0_T0_ALT_L") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMIN_1030")
+}
+
+record(ai,  "SOLN:B084:823:I0_T0_ALT_L_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMIN_1030")
+}
+
+record(ao, "SOLN:B084:823:I0_T0_ALT_H") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BLM_THRMAX_1030")
+}
+
+record(ai,  "SOLN:B084:823:I0_T0_ALT_H_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "uA")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BLM_THRMAX_1030")
+}
+
+record(bo, "SOLN:B084:823:I0_T0_ALT_L_EN") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_1030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "SOLN:B084:823:I0_T0_ALT_L_EN_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMINEN_1030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "SOLN:B084:823:I0_T0_ALT_H_EN") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_1030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "SOLN:B084:823:I0_T0_ALT_H_EN_RBV") {
+    field(DESC, "SOL2B Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BLM_THRMAXEN_1030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(longin, "MPLN:B084:MP03:1:SOFT_CH_VALUE_WORD") {
+    field(DESC, "Soft input word")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),3)SOFT_CH_VALUE_WORD")
+}
+
+record(longin, "MPLN:B084:MP03:1:SOFT_CH_ERROR_WORD") {
+    field(DESC, "Soft input word")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),3)SOFT_CH_ERROR_WORD")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_00") {
+    field(DESC, "Soft input value, channel 0")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_00")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_00_RBV") {
+    field(DESC, "Soft input value, channel 0")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_00")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_01") {
+    field(DESC, "Soft input value, channel 1")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_01")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_01_RBV") {
+    field(DESC, "Soft input value, channel 1")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_01")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_02") {
+    field(DESC, "Soft input value, channel 2")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_02")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_02_RBV") {
+    field(DESC, "Soft input value, channel 2")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_02")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_03") {
+    field(DESC, "Soft input value, channel 3")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_03")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_03_RBV") {
+    field(DESC, "Soft input value, channel 3")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_03")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_04") {
+    field(DESC, "Soft input value, channel 4")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_04")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_04_RBV") {
+    field(DESC, "Soft input value, channel 4")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_04")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_05") {
+    field(DESC, "Soft input value, channel 5")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_05")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_05_RBV") {
+    field(DESC, "Soft input value, channel 5")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_05")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_06") {
+    field(DESC, "Soft input value, channel 6")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_06")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_06_RBV") {
+    field(DESC, "Soft input value, channel 6")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_06")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_07") {
+    field(DESC, "Soft input value, channel 7")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_07")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_07_RBV") {
+    field(DESC, "Soft input value, channel 7")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_07")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_08") {
+    field(DESC, "Soft input value, channel 8")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_08")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_08_RBV") {
+    field(DESC, "Soft input value, channel 8")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_08")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_09") {
+    field(DESC, "Soft input value, channel 9")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_09")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_09_RBV") {
+    field(DESC, "Soft input value, channel 9")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_09")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_10") {
+    field(DESC, "Soft input value, channel 10")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_10")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_10_RBV") {
+    field(DESC, "Soft input value, channel 10")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_10")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_11") {
+    field(DESC, "Soft input value, channel 11")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_11")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_11_RBV") {
+    field(DESC, "Soft input value, channel 11")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_11")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_12") {
+    field(DESC, "Soft input value, channel 12")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_12")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_12_RBV") {
+    field(DESC, "Soft input value, channel 12")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_12")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_13") {
+    field(DESC, "Soft input value, channel 13")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_13")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_13_RBV") {
+    field(DESC, "Soft input value, channel 13")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_13")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_14") {
+    field(DESC, "Soft input value, channel 14")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_14")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_14_RBV") {
+    field(DESC, "Soft input value, channel 14")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_14")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_VALUE_15") {
+    field(DESC, "Soft input value, channel 15")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_15")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_VALUE_15_RBV") {
+    field(DESC, "Soft input value, channel 15")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_VALUE_15")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_00") {
+    field(DESC, "Soft input error, channel 0")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_00")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_00_RBV") {
+    field(DESC, "Soft input error, channel 0")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_00")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_01") {
+    field(DESC, "Soft input error, channel 1")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_01")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_01_RBV") {
+    field(DESC, "Soft input error, channel 1")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_01")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_02") {
+    field(DESC, "Soft input error, channel 2")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_02")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_02_RBV") {
+    field(DESC, "Soft input error, channel 2")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_02")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_03") {
+    field(DESC, "Soft input error, channel 3")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_03")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_03_RBV") {
+    field(DESC, "Soft input error, channel 3")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_03")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_04") {
+    field(DESC, "Soft input error, channel 4")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_04")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_04_RBV") {
+    field(DESC, "Soft input error, channel 4")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_04")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_05") {
+    field(DESC, "Soft input error, channel 5")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_05")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_05_RBV") {
+    field(DESC, "Soft input error, channel 5")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_05")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_06") {
+    field(DESC, "Soft input error, channel 6")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_06")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_06_RBV") {
+    field(DESC, "Soft input error, channel 6")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_06")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_07") {
+    field(DESC, "Soft input error, channel 7")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_07")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_07_RBV") {
+    field(DESC, "Soft input error, channel 7")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_07")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_08") {
+    field(DESC, "Soft input error, channel 8")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_08")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_08_RBV") {
+    field(DESC, "Soft input error, channel 8")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_08")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_09") {
+    field(DESC, "Soft input error, channel 9")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_09")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_09_RBV") {
+    field(DESC, "Soft input error, channel 9")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_09")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_10") {
+    field(DESC, "Soft input error, channel 10")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_10")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_10_RBV") {
+    field(DESC, "Soft input error, channel 10")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_10")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_11") {
+    field(DESC, "Soft input error, channel 11")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_11")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_11_RBV") {
+    field(DESC, "Soft input error, channel 11")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_11")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_12") {
+    field(DESC, "Soft input error, channel 12")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_12")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_12_RBV") {
+    field(DESC, "Soft input error, channel 12")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_12")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_13") {
+    field(DESC, "Soft input error, channel 13")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_13")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_13_RBV") {
+    field(DESC, "Soft input error, channel 13")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_13")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_14") {
+    field(DESC, "Soft input error, channel 14")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_14")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_14_RBV") {
+    field(DESC, "Soft input error, channel 14")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_14")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bo, "MPLN:B084:MP03:1:SOFT_CH_ERROR_15") {
+    field(DESC, "Soft input error, channel 15")
+    field(SCAN, "Passive")
+    field(PINI, "YES")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_15")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}
+
+record(bi, "MPLN:B084:MP03:1:SOFT_CH_ERROR_15_RBV") {
+    field(DESC, "Soft input error, channel 15")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT),3,0x01)SOFT_CH_ERROR_15")
+    field(ZNAM, "LOW")
+    field(ONAM, "HIGH")
+}

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/02/mps.env
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/02/mps.env
@@ -1,0 +1,5 @@
+epicsEnvSet("LOCATION", "B084")
+epicsEnvSet("LOCATION_INDEX", "03")
+epicsEnvSet("CARD_INDEX", "1")
+epicsEnvSet("L2MPS_PREFIX", "MPLN:${LOCATION}:MP${LOCATION_INDEX}:${CARD_INDEX}")
+epicsEnvSet("IOC_NAME", "SIOC:${LOCATION}:MP${LOCATION_INDEX}")

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/03/config.yaml
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/03/config.yaml
@@ -1,0 +1,33 @@
+# Analog application AppID
+- mmio:
+  - AmcCarrierCore:
+    - AppMps:
+      - AppMpsRegBase:
+        - mpsAppId: !<value> 3
+# Disable all thresholds
+- mmio:
+  - AmcCarrierCore:
+    - AppMps:
+      - AppMpsRegAppCh:
+        - channel:
+          - idleEn: !<value> 0x0
+          - lcls1Thr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - stdThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - idleThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - altThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/03/mps.db
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/03/mps.db
@@ -1,0 +1,2951 @@
+record(longin, "MPLN:GUNB:MP01:4:APP_ID") {
+    field(DESC, "Application ID")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)APP_ID")
+}
+record(longin, "MPLN:GUNB:MP01:4:BYTE_COUNT") {
+    field(DESC, "Number of bytes in MPS message")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)BYTE_COUNT")
+}
+record(longin, "MPLN:GUNB:MP01:4:ROLL_OVER_EN") {
+    field(DESC, "Status Counter Roll Over Enable")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)ROLL_OVER_EN")
+}
+record(longin, "MPLN:GUNB:MP01:4:TX_LINK_UP_CNT") {
+    field(DESC, "MPS TX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)TX_LINK_UP_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_0") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_0")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_1") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_1")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_2") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_2")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_3") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_3")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_4") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_4")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_5") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_5")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_6") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_6")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_7") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_7")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_8") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_8")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_9") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_9")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_10") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_10")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_11") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_11")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_12") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_12")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_LINK_UP_CNT_13") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_13")
+}
+record(longin, "MPLN:GUNB:MP01:4:TX_PKT_SENT_CNT") {
+    field(DESC, "MPS TX Packet Sent Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)TX_PKT_SENT_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_0") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_0")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_1") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_1")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_2") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_2")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_3") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_3")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_4") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_4")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_5") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_5")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_6") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_6")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_7") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_7")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_8") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_8")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_9") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_9")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_10") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_10")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_11") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_11")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_12") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_12")
+}
+record(longin, "MPLN:GUNB:MP01:4:RX_PKT_RCV_CNT_13") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_13")
+}
+record(longin, "MPLN:GUNB:MP01:4:MSG_CNT") {
+    field(DESC, "Mps message counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)MSG_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:4:LAST_MSG_APP_ID") {
+    field(DESC, "Mps last message App ID")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_APPID")
+}
+record(longin, "MPLN:GUNB:MP01:4:LAST_MSG_TMSTMP") {
+    field(DESC, "Mps last message timestamp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_TMSTMP")
+}
+record(longin, "MPLN:GUNB:MP01:4:LAST_MSG_BYTE_0") {
+    field(DESC, "Mps last message byte 0")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_0")
+}
+record(longin, "MPLN:GUNB:MP01:4:LAST_MSG_BYTE_1") {
+    field(DESC, "Mps last message byte 1")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_1")
+}
+record(longin, "MPLN:GUNB:MP01:4:LAST_MSG_BYTE_2") {
+    field(DESC, "Mps last message byte 2")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_2")
+}
+record(longin, "MPLN:GUNB:MP01:4:LAST_MSG_BYTE_3") {
+    field(DESC, "Mps last message byte 3")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_3")
+}
+record(longin, "MPLN:GUNB:MP01:4:LAST_MSG_BYTE_4") {
+    field(DESC, "Mps last message byte 4")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_4")
+}
+record(longin, "MPLN:GUNB:MP01:4:LAST_MSG_BYTE_5") {
+    field(DESC, "Mps last message byte 5")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_5")
+}
+record(bi, "MPLN:GUNB:MP01:4:DIGITAL_EN") {
+    field(DESC, "Application generates digital messages")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)DIGITAL_EN")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:4:MPS_SLOT") {
+    field(DESC, "MPS_SLOT_G")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)MPS_SLOT")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:4:PLL_LOCKED") {
+    field(DESC, "MPS PLL Lock Status")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)PLL_LOCKED")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:4:TX_LINK_UP") {
+    field(DESC, "MPS TX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)TX_LINK_UP")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_0") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_0")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_1") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_1")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_2") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_2")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_3") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_3")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_4") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_4")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_5") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_5")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_6") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_6")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_7") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_7")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_8") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_8")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_9") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_9")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_10") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_10")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_11") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_11")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_12") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_12")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:RX_LINK_UP_13") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_13")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:4:LAST_MSG_LC1_EN") {
+    field(DESC, "LCLS flag in the last message")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)LAST_MSG_LCLS")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bo, "MPLN:GUNB:MP01:4:SALT_RST_CNT") {
+    field(DESC, "Reset all the SALT status counters")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)SALT_RST_CNT")
+    field(ZNAM, "")
+    field(ONAM, "")
+}
+
+record(bo, "MPLN:GUNB:MP01:4:SALT_RST_PLL") {
+    field(DESC, "Reset the PLL")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)SALT_RST_PLL")
+    field(ZNAM, "")
+    field(ONAM, "")
+}
+
+record(longout, "MPLN:GUNB:MP01:4:BEAM_DEST_MASK") {
+    field(DESC, "One bit per dest for BPM or kicker")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)BEAM_DEST_MASK")
+}
+
+record(longin, "MPLN:GUNB:MP01:4:BEAM_DEST_MASK_RBV") {
+    field(DESC, "One bit per dest for BPM or kicker")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)BEAM_DEST_MASK")
+}
+
+record(longout, "MPLN:GUNB:MP01:4:ALT_DEST_MASK") {
+    field(DESC, "One bit per dest for alt table")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)ALT_DEST_MASK")
+}
+
+record(longin, "MPLN:GUNB:MP01:4:ALT_DEST_MASK_RBV") {
+    field(DESC, "One bit per dest for alt table")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)ALT_DEST_MASK")
+}
+
+record(longout, "MPLN:GUNB:MP01:4:MPS_VER") {
+    field(DESC, "MPS version")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)MPS_VER")
+}
+
+record(longin, "MPLN:GUNB:MP01:4:MPS_VER_RBV") {
+    field(DESC, "MPS version")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)MPS_VER")
+}
+
+record(bo, "MPLN:GUNB:MP01:4:MPS_EN") {
+    field(DESC, "MPS Enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)MPS_EN")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "MPLN:GUNB:MP01:4:MPS_EN_RBV") {
+    field(DESC, "MPS Enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)MPS_EN")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bo, "MPLN:GUNB:MP01:4:LC1_MODE") {
+    field(DESC, "LCLS operation mode")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)LCLS1_MODE")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "MPLN:GUNB:MP01:4:LC1_MODE_RBV") {
+    field(DESC, "LCLS operation mode")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)LCLS1_MODE")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(waveform, "MPLN:GUNB:MP01:4:APP_TYPE") {
+    field(DESC,    "Application type")
+    field(PINI,    "NO")
+    field(SCAN,    "I/O Intr")
+    field(DTYP,    "asynOctetRead")
+    field(NELM,    "40")
+    field(FTVL,    "CHAR")
+    field(INP,     "@asyn($(PORT,undefined),2)APP_TYPE")
+}
+
+record(longin, "BPMS:GUNB:314:X_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRNUM_0")
+}
+record(longin, "BPMS:GUNB:314:X_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRCNT_0")
+}
+record(longin, "BPMS:GUNB:314:X_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_BYTEMAP_0")
+}
+record(bo, "BPMS:GUNB:314:X_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_IDLEEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "BPMS:GUNB:314:X_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_IDLEEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:314:X_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_ALTEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:314:X_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_LCLS1EN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:X_T0_LC1_L") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_000")
+}
+
+record(ai,  "BPMS:GUNB:314:X_T0_LC1_L_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_000")
+}
+
+record(ao, "BPMS:GUNB:314:X_T0_LC1_H") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_000")
+}
+
+record(ai,  "BPMS:GUNB:314:X_T0_LC1_H_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_000")
+}
+
+record(bo, "BPMS:GUNB:314:X_T0_LC1_L_EN") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:X_T0_LC1_L_EN_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:X_T0_LC1_H_EN") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:X_T0_LC1_H_EN_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:X_T0_IDL_L") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_010")
+}
+
+record(ai,  "BPMS:GUNB:314:X_T0_IDL_L_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_010")
+}
+
+record(ao, "BPMS:GUNB:314:X_T0_IDL_H") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_010")
+}
+
+record(ai,  "BPMS:GUNB:314:X_T0_IDL_H_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_010")
+}
+
+record(bo, "BPMS:GUNB:314:X_T0_IDL_L_EN") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:X_T0_IDL_L_EN_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:X_T0_IDL_H_EN") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:X_T0_IDL_H_EN_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "BPMS:GUNB:314:X_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "mm/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "BPMS:GUNB:314:X_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_SCALE_0")
+}
+
+record(ai,      "BPMS:GUNB:314:X_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "mm/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_SCALE_0")
+}
+record(ao, "BPMS:GUNB:314:X_T0_L") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_020")
+}
+
+record(ai,  "BPMS:GUNB:314:X_T0_L_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_020")
+}
+
+record(ao, "BPMS:GUNB:314:X_T0_H") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_020")
+}
+
+record(ai,  "BPMS:GUNB:314:X_T0_H_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_020")
+}
+
+record(bo, "BPMS:GUNB:314:X_T0_L_EN") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:X_T0_L_EN_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:X_T0_H_EN") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:X_T0_H_EN_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:X_T0_ALT_L") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_030")
+}
+
+record(ai,  "BPMS:GUNB:314:X_T0_ALT_L_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_030")
+}
+
+record(ao, "BPMS:GUNB:314:X_T0_ALT_H") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_030")
+}
+
+record(ai,  "BPMS:GUNB:314:X_T0_ALT_H_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_030")
+}
+
+record(bo, "BPMS:GUNB:314:X_T0_ALT_L_EN") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:X_T0_ALT_L_EN_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:X_T0_ALT_H_EN") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:X_T0_ALT_H_EN_RBV") {
+    field(DESC, "BPM1B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(longin, "BPMS:GUNB:314:Y_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRNUM_1")
+}
+record(longin, "BPMS:GUNB:314:Y_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRCNT_1")
+}
+record(longin, "BPMS:GUNB:314:Y_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_BYTEMAP_1")
+}
+record(bo, "BPMS:GUNB:314:Y_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_IDLEEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "BPMS:GUNB:314:Y_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_IDLEEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:314:Y_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_ALTEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:314:Y_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_LCLS1EN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:Y_T0_LC1_L") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_100")
+}
+
+record(ai,  "BPMS:GUNB:314:Y_T0_LC1_L_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_100")
+}
+
+record(ao, "BPMS:GUNB:314:Y_T0_LC1_H") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_100")
+}
+
+record(ai,  "BPMS:GUNB:314:Y_T0_LC1_H_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_100")
+}
+
+record(bo, "BPMS:GUNB:314:Y_T0_LC1_L_EN") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_100")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:Y_T0_LC1_L_EN_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_100")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:Y_T0_LC1_H_EN") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_100")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:Y_T0_LC1_H_EN_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_100")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:Y_T0_IDL_L") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_110")
+}
+
+record(ai,  "BPMS:GUNB:314:Y_T0_IDL_L_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_110")
+}
+
+record(ao, "BPMS:GUNB:314:Y_T0_IDL_H") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_110")
+}
+
+record(ai,  "BPMS:GUNB:314:Y_T0_IDL_H_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_110")
+}
+
+record(bo, "BPMS:GUNB:314:Y_T0_IDL_L_EN") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_110")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:Y_T0_IDL_L_EN_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_110")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:Y_T0_IDL_H_EN") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_110")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:Y_T0_IDL_H_EN_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_110")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "BPMS:GUNB:314:Y_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "mm/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "BPMS:GUNB:314:Y_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_SCALE_1")
+}
+
+record(ai,      "BPMS:GUNB:314:Y_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "mm/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_SCALE_1")
+}
+record(ao, "BPMS:GUNB:314:Y_T0_L") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_120")
+}
+
+record(ai,  "BPMS:GUNB:314:Y_T0_L_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_120")
+}
+
+record(ao, "BPMS:GUNB:314:Y_T0_H") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_120")
+}
+
+record(ai,  "BPMS:GUNB:314:Y_T0_H_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_120")
+}
+
+record(bo, "BPMS:GUNB:314:Y_T0_L_EN") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_120")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:Y_T0_L_EN_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_120")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:Y_T0_H_EN") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_120")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:Y_T0_H_EN_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_120")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:Y_T0_ALT_L") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_130")
+}
+
+record(ai,  "BPMS:GUNB:314:Y_T0_ALT_L_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_130")
+}
+
+record(ao, "BPMS:GUNB:314:Y_T0_ALT_H") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_130")
+}
+
+record(ai,  "BPMS:GUNB:314:Y_T0_ALT_H_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_130")
+}
+
+record(bo, "BPMS:GUNB:314:Y_T0_ALT_L_EN") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_130")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:Y_T0_ALT_L_EN_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_130")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:Y_T0_ALT_H_EN") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_130")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:Y_T0_ALT_H_EN_RBV") {
+    field(DESC, "BPM1B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_130")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(longin, "BPMS:GUNB:314:TMIT_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRNUM_2")
+}
+record(longin, "BPMS:GUNB:314:TMIT_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRCNT_2")
+}
+record(longin, "BPMS:GUNB:314:TMIT_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_BYTEMAP_2")
+}
+record(bo, "BPMS:GUNB:314:TMIT_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_IDLEEN_2")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "BPMS:GUNB:314:TMIT_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_IDLEEN_2")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:314:TMIT_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_ALTEN_2")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:314:TMIT_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_LCLS1EN_2")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:TMIT_T0_LC1_L") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_200")
+}
+
+record(ai,  "BPMS:GUNB:314:TMIT_T0_LC1_L_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_200")
+}
+
+record(ao, "BPMS:GUNB:314:TMIT_T0_LC1_H") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_200")
+}
+
+record(ai,  "BPMS:GUNB:314:TMIT_T0_LC1_H_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_200")
+}
+
+record(bo, "BPMS:GUNB:314:TMIT_T0_LC1_L_EN") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_200")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:TMIT_T0_LC1_L_EN_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_200")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:TMIT_T0_LC1_H_EN") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_200")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:TMIT_T0_LC1_H_EN_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_200")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:TMIT_T0_IDL_L") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_210")
+}
+
+record(ai,  "BPMS:GUNB:314:TMIT_T0_IDL_L_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_210")
+}
+
+record(ao, "BPMS:GUNB:314:TMIT_T0_IDL_H") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_210")
+}
+
+record(ai,  "BPMS:GUNB:314:TMIT_T0_IDL_H_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_210")
+}
+
+record(bo, "BPMS:GUNB:314:TMIT_T0_IDL_L_EN") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_210")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:TMIT_T0_IDL_L_EN_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_210")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:TMIT_T0_IDL_H_EN") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_210")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:TMIT_T0_IDL_H_EN_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_210")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "BPMS:GUNB:314:TMIT_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "BPMS:GUNB:314:TMIT_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_SCALE_2")
+}
+
+record(ai,      "BPMS:GUNB:314:TMIT_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_SCALE_2")
+}
+record(ao, "BPMS:GUNB:314:TMIT_T0_L") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_220")
+}
+
+record(ai,  "BPMS:GUNB:314:TMIT_T0_L_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_220")
+}
+
+record(ao, "BPMS:GUNB:314:TMIT_T0_H") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_220")
+}
+
+record(ai,  "BPMS:GUNB:314:TMIT_T0_H_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_220")
+}
+
+record(bo, "BPMS:GUNB:314:TMIT_T0_L_EN") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_220")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:TMIT_T0_L_EN_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_220")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:TMIT_T0_H_EN") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_220")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:TMIT_T0_H_EN_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_220")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:314:TMIT_T0_ALT_L") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMIN_230")
+}
+
+record(ai,  "BPMS:GUNB:314:TMIT_T0_ALT_L_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMIN_230")
+}
+
+record(ao, "BPMS:GUNB:314:TMIT_T0_ALT_H") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BPM_THRMAX_230")
+}
+
+record(ai,  "BPMS:GUNB:314:TMIT_T0_ALT_H_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BPM_THRMAX_230")
+}
+
+record(bo, "BPMS:GUNB:314:TMIT_T0_ALT_L_EN") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_230")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:314:TMIT_T0_ALT_L_EN_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMINEN_230")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:314:TMIT_T0_ALT_H_EN") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_230")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:314:TMIT_T0_ALT_H_EN_RBV") {
+    field(DESC, "BPM1B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BPM_THRMAXEN_230")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(longin, "BPMS:GUNB:925:Y_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRNUM_1")
+}
+record(longin, "BPMS:GUNB:925:Y_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRCNT_1")
+}
+record(longin, "BPMS:GUNB:925:Y_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_BYTEMAP_1")
+}
+record(bo, "BPMS:GUNB:925:Y_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_IDLEEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "BPMS:GUNB:925:Y_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_IDLEEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:925:Y_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_ALTEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:925:Y_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_LCLS1EN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:Y_T0_LC1_L") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_100")
+}
+
+record(ai,  "BPMS:GUNB:925:Y_T0_LC1_L_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_100")
+}
+
+record(ao, "BPMS:GUNB:925:Y_T0_LC1_H") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_100")
+}
+
+record(ai,  "BPMS:GUNB:925:Y_T0_LC1_H_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_100")
+}
+
+record(bo, "BPMS:GUNB:925:Y_T0_LC1_L_EN") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_100")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:Y_T0_LC1_L_EN_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_100")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:Y_T0_LC1_H_EN") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_100")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:Y_T0_LC1_H_EN_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_100")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:Y_T0_IDL_L") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_110")
+}
+
+record(ai,  "BPMS:GUNB:925:Y_T0_IDL_L_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_110")
+}
+
+record(ao, "BPMS:GUNB:925:Y_T0_IDL_H") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_110")
+}
+
+record(ai,  "BPMS:GUNB:925:Y_T0_IDL_H_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_110")
+}
+
+record(bo, "BPMS:GUNB:925:Y_T0_IDL_L_EN") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_110")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:Y_T0_IDL_L_EN_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_110")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:Y_T0_IDL_H_EN") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_110")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:Y_T0_IDL_H_EN_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_110")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "BPMS:GUNB:925:Y_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "mm/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "BPMS:GUNB:925:Y_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_SCALE_1")
+}
+
+record(ai,      "BPMS:GUNB:925:Y_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "mm/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_SCALE_1")
+}
+record(ao, "BPMS:GUNB:925:Y_T0_L") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_120")
+}
+
+record(ai,  "BPMS:GUNB:925:Y_T0_L_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_120")
+}
+
+record(ao, "BPMS:GUNB:925:Y_T0_H") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_120")
+}
+
+record(ai,  "BPMS:GUNB:925:Y_T0_H_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_120")
+}
+
+record(bo, "BPMS:GUNB:925:Y_T0_L_EN") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_120")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:Y_T0_L_EN_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_120")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:Y_T0_H_EN") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_120")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:Y_T0_H_EN_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_120")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:Y_T0_ALT_L") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_130")
+}
+
+record(ai,  "BPMS:GUNB:925:Y_T0_ALT_L_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_130")
+}
+
+record(ao, "BPMS:GUNB:925:Y_T0_ALT_H") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_130")
+}
+
+record(ai,  "BPMS:GUNB:925:Y_T0_ALT_H_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_130")
+}
+
+record(bo, "BPMS:GUNB:925:Y_T0_ALT_L_EN") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_130")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:Y_T0_ALT_L_EN_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_130")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:Y_T0_ALT_H_EN") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_130")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:Y_T0_ALT_H_EN_RBV") {
+    field(DESC, "BPM2B Y Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_130")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(longin, "BPMS:GUNB:925:TMIT_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRNUM_2")
+}
+record(longin, "BPMS:GUNB:925:TMIT_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRCNT_2")
+}
+record(longin, "BPMS:GUNB:925:TMIT_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_BYTEMAP_2")
+}
+record(bo, "BPMS:GUNB:925:TMIT_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_IDLEEN_2")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "BPMS:GUNB:925:TMIT_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_IDLEEN_2")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:925:TMIT_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_ALTEN_2")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:925:TMIT_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_LCLS1EN_2")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:TMIT_T0_LC1_L") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_200")
+}
+
+record(ai,  "BPMS:GUNB:925:TMIT_T0_LC1_L_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_200")
+}
+
+record(ao, "BPMS:GUNB:925:TMIT_T0_LC1_H") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_200")
+}
+
+record(ai,  "BPMS:GUNB:925:TMIT_T0_LC1_H_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_200")
+}
+
+record(bo, "BPMS:GUNB:925:TMIT_T0_LC1_L_EN") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_200")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:TMIT_T0_LC1_L_EN_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_200")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:TMIT_T0_LC1_H_EN") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_200")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:TMIT_T0_LC1_H_EN_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_200")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:TMIT_T0_IDL_L") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_210")
+}
+
+record(ai,  "BPMS:GUNB:925:TMIT_T0_IDL_L_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_210")
+}
+
+record(ao, "BPMS:GUNB:925:TMIT_T0_IDL_H") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_210")
+}
+
+record(ai,  "BPMS:GUNB:925:TMIT_T0_IDL_H_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_210")
+}
+
+record(bo, "BPMS:GUNB:925:TMIT_T0_IDL_L_EN") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_210")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:TMIT_T0_IDL_L_EN_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_210")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:TMIT_T0_IDL_H_EN") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_210")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:TMIT_T0_IDL_H_EN_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_210")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "BPMS:GUNB:925:TMIT_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "BPMS:GUNB:925:TMIT_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_SCALE_2")
+}
+
+record(ai,      "BPMS:GUNB:925:TMIT_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_SCALE_2")
+}
+record(ao, "BPMS:GUNB:925:TMIT_T0_L") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_220")
+}
+
+record(ai,  "BPMS:GUNB:925:TMIT_T0_L_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_220")
+}
+
+record(ao, "BPMS:GUNB:925:TMIT_T0_H") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_220")
+}
+
+record(ai,  "BPMS:GUNB:925:TMIT_T0_H_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_220")
+}
+
+record(bo, "BPMS:GUNB:925:TMIT_T0_L_EN") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_220")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:TMIT_T0_L_EN_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_220")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:TMIT_T0_H_EN") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_220")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:TMIT_T0_H_EN_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_220")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:TMIT_T0_ALT_L") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_230")
+}
+
+record(ai,  "BPMS:GUNB:925:TMIT_T0_ALT_L_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_230")
+}
+
+record(ao, "BPMS:GUNB:925:TMIT_T0_ALT_H") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_230")
+}
+
+record(ai,  "BPMS:GUNB:925:TMIT_T0_ALT_H_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_230")
+}
+
+record(bo, "BPMS:GUNB:925:TMIT_T0_ALT_L_EN") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_230")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:TMIT_T0_ALT_L_EN_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_230")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:TMIT_T0_ALT_H_EN") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_230")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:TMIT_T0_ALT_H_EN_RBV") {
+    field(DESC, "BPM2B TMIT Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_230")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(longin, "BPMS:GUNB:925:X_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRNUM_0")
+}
+record(longin, "BPMS:GUNB:925:X_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRCNT_0")
+}
+record(longin, "BPMS:GUNB:925:X_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_BYTEMAP_0")
+}
+record(bo, "BPMS:GUNB:925:X_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_IDLEEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "BPMS:GUNB:925:X_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_IDLEEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:925:X_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_ALTEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "BPMS:GUNB:925:X_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_LCLS1EN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:X_T0_LC1_L") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_000")
+}
+
+record(ai,  "BPMS:GUNB:925:X_T0_LC1_L_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_000")
+}
+
+record(ao, "BPMS:GUNB:925:X_T0_LC1_H") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_000")
+}
+
+record(ai,  "BPMS:GUNB:925:X_T0_LC1_H_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_000")
+}
+
+record(bo, "BPMS:GUNB:925:X_T0_LC1_L_EN") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:X_T0_LC1_L_EN_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:X_T0_LC1_H_EN") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:X_T0_LC1_H_EN_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:X_T0_IDL_L") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_010")
+}
+
+record(ai,  "BPMS:GUNB:925:X_T0_IDL_L_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_010")
+}
+
+record(ao, "BPMS:GUNB:925:X_T0_IDL_H") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_010")
+}
+
+record(ai,  "BPMS:GUNB:925:X_T0_IDL_H_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_010")
+}
+
+record(bo, "BPMS:GUNB:925:X_T0_IDL_L_EN") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:X_T0_IDL_L_EN_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:X_T0_IDL_H_EN") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:X_T0_IDL_H_EN_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "BPMS:GUNB:925:X_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "mm/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "BPMS:GUNB:925:X_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_SCALE_0")
+}
+
+record(ai,      "BPMS:GUNB:925:X_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "mm/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_SCALE_0")
+}
+record(ao, "BPMS:GUNB:925:X_T0_L") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_020")
+}
+
+record(ai,  "BPMS:GUNB:925:X_T0_L_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_020")
+}
+
+record(ao, "BPMS:GUNB:925:X_T0_H") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_020")
+}
+
+record(ai,  "BPMS:GUNB:925:X_T0_H_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_020")
+}
+
+record(bo, "BPMS:GUNB:925:X_T0_L_EN") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:X_T0_L_EN_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:X_T0_H_EN") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:X_T0_H_EN_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "BPMS:GUNB:925:X_T0_ALT_L") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMIN_030")
+}
+
+record(ai,  "BPMS:GUNB:925:X_T0_ALT_L_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMIN_030")
+}
+
+record(ao, "BPMS:GUNB:925:X_T0_ALT_H") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),1)BPM_THRMAX_030")
+}
+
+record(ai,  "BPMS:GUNB:925:X_T0_ALT_H_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "mm")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),1)BPM_THRMAX_030")
+}
+
+record(bo, "BPMS:GUNB:925:X_T0_ALT_L_EN") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "BPMS:GUNB:925:X_T0_ALT_L_EN_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMINEN_030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "BPMS:GUNB:925:X_T0_ALT_H_EN") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "BPMS:GUNB:925:X_T0_ALT_H_EN_RBV") {
+    field(DESC, "BPM2B X Threshold Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),1,0x01)BPM_THRMAXEN_030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/03/mps.env
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/03/mps.env
@@ -1,0 +1,2 @@
+epicsEnvSet("L2MPS_PREFIX", "MPLN:GUNB:MP01:4")
+

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/06/config.yaml
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/06/config.yaml
@@ -1,0 +1,33 @@
+# Analog application AppID
+- mmio:
+  - AmcCarrierCore:
+    - AppMps:
+      - AppMpsRegBase:
+        - mpsAppId: !<value> 5
+# Disable all thresholds
+- mmio:
+  - AmcCarrierCore:
+    - AppMps:
+      - AppMpsRegAppCh:
+        - channel:
+          - idleEn: !<value> 0x0
+          - lcls1Thr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - stdThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - idleThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - altThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/06/mps.db
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/06/mps.db
@@ -1,0 +1,976 @@
+record(longin, "MPLN:GUNB:MP01:7:APP_ID") {
+    field(DESC, "Application ID")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)APP_ID")
+}
+record(longin, "MPLN:GUNB:MP01:7:BYTE_COUNT") {
+    field(DESC, "Number of bytes in MPS message")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)BYTE_COUNT")
+}
+record(longin, "MPLN:GUNB:MP01:7:ROLL_OVER_EN") {
+    field(DESC, "Status Counter Roll Over Enable")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)ROLL_OVER_EN")
+}
+record(longin, "MPLN:GUNB:MP01:7:TX_LINK_UP_CNT") {
+    field(DESC, "MPS TX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)TX_LINK_UP_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_0") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_0")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_1") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_1")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_2") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_2")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_3") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_3")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_4") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_4")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_5") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_5")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_6") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_6")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_7") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_7")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_8") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_8")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_9") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_9")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_10") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_10")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_11") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_11")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_12") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_12")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_LINK_UP_CNT_13") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_13")
+}
+record(longin, "MPLN:GUNB:MP01:7:TX_PKT_SENT_CNT") {
+    field(DESC, "MPS TX Packet Sent Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)TX_PKT_SENT_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_0") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_0")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_1") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_1")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_2") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_2")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_3") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_3")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_4") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_4")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_5") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_5")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_6") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_6")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_7") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_7")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_8") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_8")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_9") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_9")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_10") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_10")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_11") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_11")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_12") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_12")
+}
+record(longin, "MPLN:GUNB:MP01:7:RX_PKT_RCV_CNT_13") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_13")
+}
+record(longin, "MPLN:GUNB:MP01:7:MSG_CNT") {
+    field(DESC, "Mps message counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)MSG_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:7:LAST_MSG_APP_ID") {
+    field(DESC, "Mps last message App ID")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_APPID")
+}
+record(longin, "MPLN:GUNB:MP01:7:LAST_MSG_TMSTMP") {
+    field(DESC, "Mps last message timestamp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_TMSTMP")
+}
+record(longin, "MPLN:GUNB:MP01:7:LAST_MSG_BYTE_0") {
+    field(DESC, "Mps last message byte 0")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_0")
+}
+record(longin, "MPLN:GUNB:MP01:7:LAST_MSG_BYTE_1") {
+    field(DESC, "Mps last message byte 1")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_1")
+}
+record(longin, "MPLN:GUNB:MP01:7:LAST_MSG_BYTE_2") {
+    field(DESC, "Mps last message byte 2")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_2")
+}
+record(longin, "MPLN:GUNB:MP01:7:LAST_MSG_BYTE_3") {
+    field(DESC, "Mps last message byte 3")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_3")
+}
+record(longin, "MPLN:GUNB:MP01:7:LAST_MSG_BYTE_4") {
+    field(DESC, "Mps last message byte 4")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_4")
+}
+record(longin, "MPLN:GUNB:MP01:7:LAST_MSG_BYTE_5") {
+    field(DESC, "Mps last message byte 5")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_5")
+}
+record(bi, "MPLN:GUNB:MP01:7:DIGITAL_EN") {
+    field(DESC, "Application generates digital messages")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)DIGITAL_EN")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:7:MPS_SLOT") {
+    field(DESC, "MPS_SLOT_G")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)MPS_SLOT")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:7:PLL_LOCKED") {
+    field(DESC, "MPS PLL Lock Status")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)PLL_LOCKED")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:7:TX_LINK_UP") {
+    field(DESC, "MPS TX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)TX_LINK_UP")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_0") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_0")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_1") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_1")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_2") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_2")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_3") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_3")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_4") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_4")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_5") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_5")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_6") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_6")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_7") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_7")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_8") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_8")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_9") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_9")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_10") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_10")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_11") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_11")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_12") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_12")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:RX_LINK_UP_13") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_13")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:7:LAST_MSG_LC1_EN") {
+    field(DESC, "LCLS flag in the last message")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)LAST_MSG_LCLS")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bo, "MPLN:GUNB:MP01:7:SALT_RST_CNT") {
+    field(DESC, "Reset all the SALT status counters")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)SALT_RST_CNT")
+    field(ZNAM, "")
+    field(ONAM, "")
+}
+
+record(bo, "MPLN:GUNB:MP01:7:SALT_RST_PLL") {
+    field(DESC, "Reset the PLL")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)SALT_RST_PLL")
+    field(ZNAM, "")
+    field(ONAM, "")
+}
+
+record(longout, "MPLN:GUNB:MP01:7:BEAM_DEST_MASK") {
+    field(DESC, "One bit per dest for BPM or kicker")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)BEAM_DEST_MASK")
+}
+
+record(longin, "MPLN:GUNB:MP01:7:BEAM_DEST_MASK_RBV") {
+    field(DESC, "One bit per dest for BPM or kicker")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)BEAM_DEST_MASK")
+}
+
+record(longout, "MPLN:GUNB:MP01:7:ALT_DEST_MASK") {
+    field(DESC, "One bit per dest for alt table")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)ALT_DEST_MASK")
+}
+
+record(longin, "MPLN:GUNB:MP01:7:ALT_DEST_MASK_RBV") {
+    field(DESC, "One bit per dest for alt table")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)ALT_DEST_MASK")
+}
+
+record(longout, "MPLN:GUNB:MP01:7:MPS_VER") {
+    field(DESC, "MPS version")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)MPS_VER")
+}
+
+record(longin, "MPLN:GUNB:MP01:7:MPS_VER_RBV") {
+    field(DESC, "MPS version")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)MPS_VER")
+}
+
+record(bo, "MPLN:GUNB:MP01:7:MPS_EN") {
+    field(DESC, "MPS Enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)MPS_EN")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "MPLN:GUNB:MP01:7:MPS_EN_RBV") {
+    field(DESC, "MPS Enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)MPS_EN")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bo, "MPLN:GUNB:MP01:7:LC1_MODE") {
+    field(DESC, "LCLS operation mode")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)LCLS1_MODE")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "MPLN:GUNB:MP01:7:LC1_MODE_RBV") {
+    field(DESC, "LCLS operation mode")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)LCLS1_MODE")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(waveform, "MPLN:GUNB:MP01:7:APP_TYPE") {
+    field(DESC,    "Application type")
+    field(PINI,    "NO")
+    field(SCAN,    "I/O Intr")
+    field(DTYP,    "asynOctetRead")
+    field(NELM,    "40")
+    field(FTVL,    "CHAR")
+    field(INP,     "@asyn($(PORT,undefined),2)APP_TYPE")
+}
+
+record(longin, "FARC:GUNB:999:CHARGE_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRNUM_0")
+}
+record(longin, "FARC:GUNB:999:CHARGE_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRCNT_0")
+}
+record(longin, "FARC:GUNB:999:CHARGE_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_BYTEMAP_0")
+}
+record(bo, "FARC:GUNB:999:CHARGE_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_IDLEEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "FARC:GUNB:999:CHARGE_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_IDLEEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "FARC:GUNB:999:CHARGE_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_ALTEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "FARC:GUNB:999:CHARGE_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_LCLS1EN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "FARC:GUNB:999:CHARGE_T0_LC1_L") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_000")
+}
+
+record(ai,  "FARC:GUNB:999:CHARGE_T0_LC1_L_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_000")
+}
+
+record(ao, "FARC:GUNB:999:CHARGE_T0_LC1_H") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_000")
+}
+
+record(ai,  "FARC:GUNB:999:CHARGE_T0_LC1_H_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_000")
+}
+
+record(bo, "FARC:GUNB:999:CHARGE_T0_LC1_L_EN") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "FARC:GUNB:999:CHARGE_T0_LC1_L_EN_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "FARC:GUNB:999:CHARGE_T0_LC1_H_EN") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "FARC:GUNB:999:CHARGE_T0_LC1_H_EN_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "FARC:GUNB:999:CHARGE_T0_IDL_L") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_010")
+}
+
+record(ai,  "FARC:GUNB:999:CHARGE_T0_IDL_L_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_010")
+}
+
+record(ao, "FARC:GUNB:999:CHARGE_T0_IDL_H") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_010")
+}
+
+record(ai,  "FARC:GUNB:999:CHARGE_T0_IDL_H_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_010")
+}
+
+record(bo, "FARC:GUNB:999:CHARGE_T0_IDL_L_EN") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "FARC:GUNB:999:CHARGE_T0_IDL_L_EN_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "FARC:GUNB:999:CHARGE_T0_IDL_H_EN") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "FARC:GUNB:999:CHARGE_T0_IDL_H_EN_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "FARC:GUNB:999:CHARGE_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "FARC:GUNB:999:CHARGE_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_SCALE_0")
+}
+
+record(ai,      "FARC:GUNB:999:CHARGE_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_SCALE_0")
+}
+record(ao, "FARC:GUNB:999:CHARGE_T0_L") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_020")
+}
+
+record(ai,  "FARC:GUNB:999:CHARGE_T0_L_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_020")
+}
+
+record(ao, "FARC:GUNB:999:CHARGE_T0_H") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_020")
+}
+
+record(ai,  "FARC:GUNB:999:CHARGE_T0_H_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_020")
+}
+
+record(bo, "FARC:GUNB:999:CHARGE_T0_L_EN") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "FARC:GUNB:999:CHARGE_T0_L_EN_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "FARC:GUNB:999:CHARGE_T0_H_EN") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "FARC:GUNB:999:CHARGE_T0_H_EN_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "FARC:GUNB:999:CHARGE_T0_ALT_L") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_030")
+}
+
+record(ai,  "FARC:GUNB:999:CHARGE_T0_ALT_L_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_030")
+}
+
+record(ao, "FARC:GUNB:999:CHARGE_T0_ALT_H") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_030")
+}
+
+record(ai,  "FARC:GUNB:999:CHARGE_T0_ALT_H_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_030")
+}
+
+record(bo, "FARC:GUNB:999:CHARGE_T0_ALT_L_EN") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "FARC:GUNB:999:CHARGE_T0_ALT_L_EN_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "FARC:GUNB:999:CHARGE_T0_ALT_H_EN") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "FARC:GUNB:999:CHARGE_T0_ALT_H_EN_RBV") {
+    field(DESC, "FC01 Integrator #0 Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/06/mps.env
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/06/mps.env
@@ -1,0 +1,2 @@
+epicsEnvSet("L2MPS_PREFIX", "MPLN:GUNB:MP01:7")
+

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/07/config.yaml
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/07/config.yaml
@@ -1,0 +1,33 @@
+# Analog application AppID
+- mmio:
+  - AmcCarrierCore:
+    - AppMps:
+      - AppMpsRegBase:
+        - mpsAppId: !<value> 6
+# Disable all thresholds
+- mmio:
+  - AmcCarrierCore:
+    - AppMps:
+      - AppMpsRegAppCh:
+        - channel:
+          - idleEn: !<value> 0x0
+          - lcls1Thr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - stdThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - idleThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0
+          - altThr:
+            - minEn: !<value> 0x0
+            - maxEn: !<value> 0x0
+            - min:   !<value> 0x0
+            - max:   !<value> 0x0

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/07/mps.db
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/07/mps.db
@@ -1,0 +1,1371 @@
+record(longin, "MPLN:GUNB:MP01:8:APP_ID") {
+    field(DESC, "Application ID")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)APP_ID")
+}
+record(longin, "MPLN:GUNB:MP01:8:BYTE_COUNT") {
+    field(DESC, "Number of bytes in MPS message")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)BYTE_COUNT")
+}
+record(longin, "MPLN:GUNB:MP01:8:ROLL_OVER_EN") {
+    field(DESC, "Status Counter Roll Over Enable")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)ROLL_OVER_EN")
+}
+record(longin, "MPLN:GUNB:MP01:8:TX_LINK_UP_CNT") {
+    field(DESC, "MPS TX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)TX_LINK_UP_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_0") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_0")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_1") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_1")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_2") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_2")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_3") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_3")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_4") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_4")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_5") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_5")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_6") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_6")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_7") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_7")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_8") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_8")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_9") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_9")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_10") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_10")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_11") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_11")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_12") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_12")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_LINK_UP_CNT_13") {
+    field(DESC, "MPS RX LinkUp Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_LINK_UP_CNT_13")
+}
+record(longin, "MPLN:GUNB:MP01:8:TX_PKT_SENT_CNT") {
+    field(DESC, "MPS TX Packet Sent Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)TX_PKT_SENT_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_0") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_0")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_1") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_1")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_2") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_2")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_3") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_3")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_4") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_4")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_5") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_5")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_6") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_6")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_7") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_7")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_8") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_8")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_9") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_9")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_10") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_10")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_11") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_11")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_12") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_12")
+}
+record(longin, "MPLN:GUNB:MP01:8:RX_PKT_RCV_CNT_13") {
+    field(DESC, "MPS RX Packet Received Counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)RX_PKT_RCV_CNT_13")
+}
+record(longin, "MPLN:GUNB:MP01:8:MSG_CNT") {
+    field(DESC, "Mps message counter")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)MSG_CNT")
+}
+record(longin, "MPLN:GUNB:MP01:8:LAST_MSG_APP_ID") {
+    field(DESC, "Mps last message App ID")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_APPID")
+}
+record(longin, "MPLN:GUNB:MP01:8:LAST_MSG_TMSTMP") {
+    field(DESC, "Mps last message timestamp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_TMSTMP")
+}
+record(longin, "MPLN:GUNB:MP01:8:LAST_MSG_BYTE_0") {
+    field(DESC, "Mps last message byte 0")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_0")
+}
+record(longin, "MPLN:GUNB:MP01:8:LAST_MSG_BYTE_1") {
+    field(DESC, "Mps last message byte 1")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_1")
+}
+record(longin, "MPLN:GUNB:MP01:8:LAST_MSG_BYTE_2") {
+    field(DESC, "Mps last message byte 2")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_2")
+}
+record(longin, "MPLN:GUNB:MP01:8:LAST_MSG_BYTE_3") {
+    field(DESC, "Mps last message byte 3")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_3")
+}
+record(longin, "MPLN:GUNB:MP01:8:LAST_MSG_BYTE_4") {
+    field(DESC, "Mps last message byte 4")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_4")
+}
+record(longin, "MPLN:GUNB:MP01:8:LAST_MSG_BYTE_5") {
+    field(DESC, "Mps last message byte 5")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)LAST_MSG_BYTE_5")
+}
+record(bi, "MPLN:GUNB:MP01:8:DIGITAL_EN") {
+    field(DESC, "Application generates digital messages")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)DIGITAL_EN")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:8:MPS_SLOT") {
+    field(DESC, "MPS_SLOT_G")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)MPS_SLOT")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:8:PLL_LOCKED") {
+    field(DESC, "MPS PLL Lock Status")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)PLL_LOCKED")
+    field(ZNAM, "No")
+    field(ONAM, "Yes")
+}
+record(bi, "MPLN:GUNB:MP01:8:TX_LINK_UP") {
+    field(DESC, "MPS TX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)TX_LINK_UP")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_0") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_0")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_1") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_1")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_2") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_2")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_3") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_3")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_4") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_4")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_5") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_5")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_6") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_6")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_7") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_7")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_8") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_8")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_9") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_9")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_10") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_10")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_11") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_11")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_12") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_12")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:RX_LINK_UP_13") {
+    field(DESC, "MPS RX LinkUp")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)RX_LINK_UP_13")
+    field(ZNAM, "Down")
+    field(ONAM, "Up")
+}
+record(bi, "MPLN:GUNB:MP01:8:LAST_MSG_LC1_EN") {
+    field(DESC, "LCLS flag in the last message")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)LAST_MSG_LCLS")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bo, "MPLN:GUNB:MP01:8:SALT_RST_CNT") {
+    field(DESC, "Reset all the SALT status counters")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)SALT_RST_CNT")
+    field(ZNAM, "")
+    field(ONAM, "")
+}
+
+record(bo, "MPLN:GUNB:MP01:8:SALT_RST_PLL") {
+    field(DESC, "Reset the PLL")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)SALT_RST_PLL")
+    field(ZNAM, "")
+    field(ONAM, "")
+}
+
+record(longout, "MPLN:GUNB:MP01:8:BEAM_DEST_MASK") {
+    field(DESC, "One bit per dest for BPM or kicker")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)BEAM_DEST_MASK")
+}
+
+record(longin, "MPLN:GUNB:MP01:8:BEAM_DEST_MASK_RBV") {
+    field(DESC, "One bit per dest for BPM or kicker")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)BEAM_DEST_MASK")
+}
+
+record(longout, "MPLN:GUNB:MP01:8:ALT_DEST_MASK") {
+    field(DESC, "One bit per dest for alt table")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)ALT_DEST_MASK")
+}
+
+record(longin, "MPLN:GUNB:MP01:8:ALT_DEST_MASK_RBV") {
+    field(DESC, "One bit per dest for alt table")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)ALT_DEST_MASK")
+}
+
+record(longout, "MPLN:GUNB:MP01:8:MPS_VER") {
+    field(DESC, "MPS version")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT,undefined),2)MPS_VER")
+}
+
+record(longin, "MPLN:GUNB:MP01:8:MPS_VER_RBV") {
+    field(DESC, "MPS version")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),2)MPS_VER")
+}
+
+record(bo, "MPLN:GUNB:MP01:8:MPS_EN") {
+    field(DESC, "MPS Enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)MPS_EN")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "MPLN:GUNB:MP01:8:MPS_EN_RBV") {
+    field(DESC, "MPS Enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)MPS_EN")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bo, "MPLN:GUNB:MP01:8:LC1_MODE") {
+    field(DESC, "LCLS operation mode")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),2,0x01)LCLS1_MODE")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "MPLN:GUNB:MP01:8:LC1_MODE_RBV") {
+    field(DESC, "LCLS operation mode")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),2,0x01)LCLS1_MODE")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(waveform, "MPLN:GUNB:MP01:8:APP_TYPE") {
+    field(DESC,    "Application type")
+    field(PINI,    "NO")
+    field(SCAN,    "I/O Intr")
+    field(DTYP,    "asynOctetRead")
+    field(NELM,    "40")
+    field(FTVL,    "CHAR")
+    field(INP,     "@asyn($(PORT,undefined),2)APP_TYPE")
+}
+
+record(longin, "TORO:GUNB:360:CHARGE_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRNUM_0")
+}
+record(longin, "TORO:GUNB:360:CHARGE_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRCNT_0")
+}
+record(longin, "TORO:GUNB:360:CHARGE_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_BYTEMAP_0")
+}
+record(bo, "TORO:GUNB:360:CHARGE_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_IDLEEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "TORO:GUNB:360:CHARGE_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_IDLEEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "TORO:GUNB:360:CHARGE_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_ALTEN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "TORO:GUNB:360:CHARGE_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_LCLS1EN_0")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "TORO:GUNB:360:CHARGE_T0_LC1_L") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_000")
+}
+
+record(ai,  "TORO:GUNB:360:CHARGE_T0_LC1_L_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_000")
+}
+
+record(ao, "TORO:GUNB:360:CHARGE_T0_LC1_H") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_000")
+}
+
+record(ai,  "TORO:GUNB:360:CHARGE_T0_LC1_H_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_000")
+}
+
+record(bo, "TORO:GUNB:360:CHARGE_T0_LC1_L_EN") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "TORO:GUNB:360:CHARGE_T0_LC1_L_EN_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "TORO:GUNB:360:CHARGE_T0_LC1_H_EN") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_000")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "TORO:GUNB:360:CHARGE_T0_LC1_H_EN_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_000")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "TORO:GUNB:360:CHARGE_T0_IDL_L") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_010")
+}
+
+record(ai,  "TORO:GUNB:360:CHARGE_T0_IDL_L_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_010")
+}
+
+record(ao, "TORO:GUNB:360:CHARGE_T0_IDL_H") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_010")
+}
+
+record(ai,  "TORO:GUNB:360:CHARGE_T0_IDL_H_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_010")
+}
+
+record(bo, "TORO:GUNB:360:CHARGE_T0_IDL_L_EN") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "TORO:GUNB:360:CHARGE_T0_IDL_L_EN_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "TORO:GUNB:360:CHARGE_T0_IDL_H_EN") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_010")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "TORO:GUNB:360:CHARGE_T0_IDL_H_EN_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_010")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "TORO:GUNB:360:CHARGE_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "TORO:GUNB:360:CHARGE_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_SCALE_0")
+}
+
+record(ai,      "TORO:GUNB:360:CHARGE_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_SCALE_0")
+}
+record(ao, "TORO:GUNB:360:CHARGE_T0_L") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_020")
+}
+
+record(ai,  "TORO:GUNB:360:CHARGE_T0_L_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_020")
+}
+
+record(ao, "TORO:GUNB:360:CHARGE_T0_H") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_020")
+}
+
+record(ai,  "TORO:GUNB:360:CHARGE_T0_H_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_020")
+}
+
+record(bo, "TORO:GUNB:360:CHARGE_T0_L_EN") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "TORO:GUNB:360:CHARGE_T0_L_EN_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "TORO:GUNB:360:CHARGE_T0_H_EN") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_020")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "TORO:GUNB:360:CHARGE_T0_H_EN_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_020")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "TORO:GUNB:360:CHARGE_T0_ALT_L") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_030")
+}
+
+record(ai,  "TORO:GUNB:360:CHARGE_T0_ALT_L_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_030")
+}
+
+record(ao, "TORO:GUNB:360:CHARGE_T0_ALT_H") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_030")
+}
+
+record(ai,  "TORO:GUNB:360:CHARGE_T0_ALT_H_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_030")
+}
+
+record(bo, "TORO:GUNB:360:CHARGE_T0_ALT_L_EN") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "TORO:GUNB:360:CHARGE_T0_ALT_L_EN_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "TORO:GUNB:360:CHARGE_T0_ALT_H_EN") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_030")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "TORO:GUNB:360:CHARGE_T0_ALT_H_EN_RBV") {
+    field(DESC, "IM01B Charge Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_030")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(longin, "TORO:GUNB:360:DIFF_THR_CH") {
+    field(DESC, "Threshold channel")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRNUM_1")
+}
+record(longin, "TORO:GUNB:360:DIFF_THR_CNT") {
+    field(DESC, "Threshold count")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRCNT_1")
+}
+record(longin, "TORO:GUNB:360:DIFF_THR_BYTEMAP") {
+    field(DESC, "Threshold byte map")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynInt32")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_BYTEMAP_1")
+}
+record(bo, "TORO:GUNB:360:DIFF_IDL_EN") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_IDLEEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bi, "TORO:GUNB:360:DIFF_IDL_EN_RBV") {
+    field(DESC, "IDLE table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_IDLEEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "TORO:GUNB:360:DIFF_ALT_EN") {
+    field(DESC, "ALT table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_ALTEN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(bi, "TORO:GUNB:360:DIFF_LC1_EN") {
+    field(DESC, "LCLS1 table enabled")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_LCLS1EN_1")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "TORO:GUNB:360:DIFF_T0_LC1_L") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_100")
+}
+
+record(ai,  "TORO:GUNB:360:DIFF_T0_LC1_L_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_100")
+}
+
+record(ao, "TORO:GUNB:360:DIFF_T0_LC1_H") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_100")
+}
+
+record(ai,  "TORO:GUNB:360:DIFF_T0_LC1_H_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_100")
+}
+
+record(bo, "TORO:GUNB:360:DIFF_T0_LC1_L_EN") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_100")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "TORO:GUNB:360:DIFF_T0_LC1_L_EN_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_100")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "TORO:GUNB:360:DIFF_T0_LC1_H_EN") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_100")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "TORO:GUNB:360:DIFF_T0_LC1_H_EN_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_100")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "TORO:GUNB:360:DIFF_T0_IDL_L") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_110")
+}
+
+record(ai,  "TORO:GUNB:360:DIFF_T0_IDL_L_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_110")
+}
+
+record(ao, "TORO:GUNB:360:DIFF_T0_IDL_H") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_110")
+}
+
+record(ai,  "TORO:GUNB:360:DIFF_T0_IDL_H_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_110")
+}
+
+record(bo, "TORO:GUNB:360:DIFF_T0_IDL_L_EN") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_110")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "TORO:GUNB:360:DIFF_T0_IDL_L_EN_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_110")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "TORO:GUNB:360:DIFF_T0_IDL_H_EN") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_110")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "TORO:GUNB:360:DIFF_T0_IDL_H_EN_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_110")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao,      "TORO:GUNB:360:DIFF_SF") {
+    field(DESC, "Scale factor")
+    field(SCAN, "1 second")
+    field(PINI, "YES")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(OMSL, "closed_loop")
+    field(OIF,  "Full")
+    field(DOL,  "TORO:GUNB:360:DIFF_FWSCL")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_SCALE_1")
+}
+
+record(ai,      "TORO:GUNB:360:DIFF_SF_RBV") {
+    field(DESC, "Scale factor")
+    field(SCAN, "I/O Intr")
+    field(EGU,  "Nel/raw")
+    field(PREC, "4")
+    field(DTYP, "asynFloat64")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_SCALE_1")
+}
+record(ao, "TORO:GUNB:360:DIFF_T0_L") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_120")
+}
+
+record(ai,  "TORO:GUNB:360:DIFF_T0_L_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_120")
+}
+
+record(ao, "TORO:GUNB:360:DIFF_T0_H") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_120")
+}
+
+record(ai,  "TORO:GUNB:360:DIFF_T0_H_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_120")
+}
+
+record(bo, "TORO:GUNB:360:DIFF_T0_L_EN") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_120")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "TORO:GUNB:360:DIFF_T0_L_EN_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_120")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "TORO:GUNB:360:DIFF_T0_H_EN") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_120")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "TORO:GUNB:360:DIFF_T0_H_EN_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_120")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+record(ao, "TORO:GUNB:360:DIFF_T0_ALT_L") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMIN_130")
+}
+
+record(ai,  "TORO:GUNB:360:DIFF_T0_ALT_L_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMIN_130")
+}
+
+record(ao, "TORO:GUNB:360:DIFF_T0_ALT_H") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(OUT,  "@asyn($(PORT,undefined),0)BCM_THRMAX_130")
+}
+
+record(ai,  "TORO:GUNB:360:DIFF_T0_ALT_H_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynFloat64")
+    field(EGU,  "Nel")
+    field(PREC, "2")
+    field(INP,  "@asyn($(PORT,undefined),0)BCM_THRMAX_130")
+}
+
+record(bo, "TORO:GUNB:360:DIFF_T0_ALT_L_EN") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_130")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi, "TORO:GUNB:360:DIFF_T0_ALT_L_EN_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMINEN_130")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}
+
+record(bo,      "TORO:GUNB:360:DIFF_T0_ALT_H_EN") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "Passive")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(OUT,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_130")
+    field(ZNAM, "Disable")
+    field(ONAM, "Enable")
+}
+
+record(bi,      "TORO:GUNB:360:DIFF_T0_ALT_H_EN_RBV") {
+    field(DESC, "IM01B/BPM1B Difference Fault")
+    field(SCAN, "I/O Intr")
+    field(PINI, "NO")
+    field(DTYP, "asynUInt32Digital")
+    field(INP,  "@asynMask($(PORT,undefined),0,0x01)BCM_THRMAXEN_130")
+    field(ZNAM, "Disabled")
+    field(ONAM, "Enabled")
+}

--- a/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/07/mps.env
+++ b/iocBoot/sioc-b084-mp03/mps_database_output/app_db/cpu-b084-hp03/0001/07/mps.env
@@ -1,0 +1,2 @@
+epicsEnvSet("L2MPS_PREFIX", "MPLN:GUNB:MP01:8")
+

--- a/iocBoot/sioc-b084-mp03/st.cmd
+++ b/iocBoot/sioc-b084-mp03/st.cmd
@@ -1,0 +1,230 @@
+#!../../bin/linuxRT-x86_64/l2MpsLN
+
+## You may have to change l2MpsLN to something else
+## everywhere it appears in this file
+
+< envPaths
+
+# ===========================================
+#            ENVIRONMENT VARIABLES
+# ===========================================
+
+# CPSW Port names
+epicsEnvSet("L2MPSASYN_PORT","L2MPSASYN_PORT")
+epicsEnvSet("YCPSWASYN_PORT","YCPSWASYN_PORT")
+epicsEnvSet("TPRTRIGGER_PORT","TPRTRIGGER_PORT")
+epicsEnvSet("TPRPATTERN_PORT","TPRPATTERN_PORT")
+
+# Point 'YAML_PATH' to the yaml_fixes directory
+epicsEnvSet("YAML_PATH", "${TOP}/firmware/yaml_fixes")
+
+# Location to download the YAML file from the FPGA
+epicsEnvSet("YAML_DIR","${IOC_DATA}/${IOC}/yaml")
+
+# YAML file
+epicsEnvSet("YAML","${YAML_DIR}/000TopLevel.yaml")
+
+# Defaults Yaml file
+epicsEnvSet("DEFAULTS_FILE", "${YAML_DIR}/config/defaults.yaml")
+
+# YCPSWASYN Dictionary file
+epicsEnvSet("YCPSWASYN_DICT_FILE", "firmware/mpsLN.dict")
+
+# FPGA IP Address
+epicsEnvSet("FPGA_IP","10.0.1.102")
+
+# *********************************************
+# **** Environment variables for IOC Admin ****
+epicsEnvSet("ENGINEER","Jeremy Mock")
+
+# ======================================
+# Start from TOP
+# ======================================
+cd ${TOP}
+
+# ===========================================
+#               DBD LOADING
+# ===========================================
+## Register all support components
+dbLoadDatabase("dbd/l2MpsLN.dbd",0,0)
+l2MpsLN_registerRecordDeviceDriver(pdbbase)
+
+# ===========================================
+#              DRIVER SETUP
+# ===========================================
+
+## yamlDownloader
+DownloadYamlFile("${FPGA_IP}", "${YAML_DIR}")
+
+## yamlLoader
+cpswLoadYamlFile("${YAML}", "NetIODev", "", "${FPGA_IP}")
+
+## Set MPS Configuration location
+# setMpsConfigurationPath(
+#   Path)                   # Path to the MPS configuraton TOP directory
+#
+# In DEV, we temporary point to a local copy in this IOC application
+setMpsConfigurationPath("iocBoot/${IOC}/mps_database_output")
+
+## LCLS-II MPS
+# L2MPSASYNConfig(
+#    Port Name)            # the name given to this port driver
+L2MPSASYNConfig("${L2MPSASYN_PORT}")
+
+## Set the MpsManager hostname and port number
+# L2MPSASYNSetManagerHost(
+#    MpsManagerHostName,   # Server hostname
+#    MpsManagerPortNumber) # Server port number
+#
+# In DEV, the MpsManager runs in lcls-dev3, default port number.
+L2MPSASYNSetManagerHost("lcls-dev3", 0)
+
+## Configure the LCLS1 BSA driver
+# L2MpsL1BsaConfig(
+#    streamName,                # Name of the CPSW stream interface for the LCLS1 BSA data
+#    recordPrefix)              # Record name prefix for the LCLS1 BSA PVs
+L2MpsL1BsaConfig("Lcls1BsaStream", "${L2MPS_PREFIX}")
+
+## Configure the YCPSWASYN driver
+# YCPSWASYNConfig(
+#    Port Name,                 # The name given to this port driver
+#    Root Path                  # OPTIONAL: Root path to start the generation. If empty, the Yaml root will be used
+#    Record name Prefix,        # Record name prefix
+#    DB Autogeneration mode,    # Set autogeneration of records. 0: disabled, 1: Enable usig maps, 2: Enabled using hash names.
+#    Load dictionary)           # Dictionary file path with registers to load. An empty string will disable this function
+YCPSWASYNConfig("${YCPSWASYN_PORT}", "", "", "0", "${YCPSWASYN_DICT_FILE}")
+
+## Configure the tprTrigger driver
+# tprTriggerAsynDriverConfigure(
+#    Port name,                 # The name given to this port driver
+#    Root path)                 # Root path to the AmcCarrierCore register area
+tprTriggerAsynDriverConfigure("${TPRTRIGGER_PORT}", "mmio/AmcCarrierCore")
+
+## Configure the tprPattern driver
+# tprPatternAsynDriverConfigure(
+#    Port name,                 # The name given to this port driver
+#    Root path,                 # Root path to the AmcCarrierCore register area
+#    Stream name)               # Name of the timing stream
+tprPatternAsynDriverConfigure("${TPRPATTERN_PORT}", "mmio/AmcCarrierCore", "tstream")
+
+# ==========================================
+# Load application specific configurations
+# ==========================================
+# Load the defautl configuration
+cpswLoadConfigFile("${DEFAULTS_FILE}", "mmio")
+
+# ==========================================
+
+# ===========================================
+#               ASYN MASKS
+# ===========================================
+asynSetTraceMask("${L2MPSASYN_PORT}",, -1, 0)
+asynSetTraceMask("${YCPSWASYN_PORT}",, -1, 0)
+
+# ===========================================
+#               DB LOADING
+# ===========================================
+# Link Node database
+dbLoadRecords("db/mpsLN.db", "P=${L2MPS_PREFIX}, PORT=${YCPSWASYN_PORT}")
+
+# tprTrigger database
+dbLoadRecords("db/tprTrig.db", "PORT=${TPRTRIGGER_PORT},LOCA=${LOCATION},IOC_UNIT=MP${LOCATION_INDEX},INST=0")
+
+# tprPattern database
+dbLoadRecords("db/tprPattern.db", "PORT=${TPRPATTERN_PORT},LOCA=${LOCATION},IOC_UNIT=MP${LOCATION_INDEX},INST=0")
+
+# Save/load configuration database
+dbLoadRecords("db/saveLoadConfig.db", "P=${L2MPS_PREFIX}, PORT=${YCPSWASYN_PORT}")
+
+# **********************************************************************
+# **** Load iocAdmin databases to support IOC Health and monitoring ****
+dbLoadRecords("db/iocAdminSoft.db","IOC=${IOC_NAME}")
+dbLoadRecords("db/iocAdminScanMon.db","IOC=${IOC_NAME}")
+
+# The following database is a result of a python parser
+# which looks at RELEASE_SITE and RELEASE to discover
+# versions of software your IOC is referencing
+# The python parser is part of iocAdmin
+dbLoadRecords("db/iocRelease.db","IOC=${IOC}")
+
+# *******************************************
+# **** Load database for autosave status ****
+dbLoadRecords("db/save_restoreStatus.db", "P=${L2MPS_PREFIX}:")
+
+# ===========================================
+#           SETUP AUTOSAVE/RESTORE
+# ===========================================
+
+# If all PVs don't connect continue anyway
+save_restoreSet_IncompleteSetsOk(1)
+
+# created save/restore backup files with date string
+# useful for recovery.
+save_restoreSet_DatedBackupFiles(1)
+
+# Where to find the list of PVs to save
+# Where "/data" is an NFS mount point setup when linuxRT target
+# boots up.
+set_requestfile_path("${IOC_DATA}/${IOC}/autosave-req")
+set_requestfile_path("${TOP}/iocBoot/common")
+
+# Where to write the save files that will be used to restore
+set_savefile_path("${IOC_DATA}/${IOC}/autosave")
+
+# Prefix that is use to update save/restore status database
+# records
+save_restoreSet_UseStatusPVs(1)
+save_restoreSet_status_prefix("${L2MPS_PREFIX}:")
+
+## Restore datasets
+set_pass0_restoreFile("info_positions.sav")
+set_pass0_restoreFile("info_settings.sav")
+set_pass1_restoreFile("info_settings.sav")
+set_pass1_restoreFile("manual_settings.sav")
+set_pass0_restoreFile("ana_units.sav")
+
+# ===========================================
+#          CHANNEL ACESS SECURITY
+# ===========================================
+# This is required if you use caPutLog.
+# Set access security filea
+# Load common LCLS Access Configuration File
+< ${ACF_INIT}
+
+# ===========================================
+#               IOC INIT
+# ===========================================
+iocInit()
+
+# ===========================================
+#           AUTOSAVE TASKS
+# ===========================================
+
+# Wait before building autosave files
+epicsThreadSleep(1)
+
+# Generate the autosave PV list
+# Note we need change directory to
+# where we are saving the restore
+# request file, and then we go back
+# ${TOP}.
+cd ${IOC_DATA}/${IOC}/autosave-req
+makeAutosaveFiles()
+cd ${TOP}
+
+# Start the save_restore task
+# save changes on change, but no faster
+# than every 5 seconds.
+# Note: the last arg cannot be set to 0
+create_monitor_set("info_positions.req", 5 )
+create_monitor_set("info_settings.req" , 5 )
+create_monitor_set("manual_settings.req" , 5 )
+create_monitor_set("ana_units.req" , 30, "P=${L2MPS_PREFIX}" )
+
+# - FIXME -
+# Workaround: Adding this value and setting PINI=YES
+# in the record doesn't work properly with input
+# buffer start addresses. Setting the initial value
+# here for now.
+dbpf ${L2MPS_PREFIX}:DM0_BUFFER_SIZE 1000000
+dbpf ${L2MPS_PREFIX}:DM1_BUFFER_SIZE 1000000

--- a/l2MpsLNApp/Db/Makefile
+++ b/l2MpsLNApp/Db/Makefile
@@ -43,6 +43,9 @@ IOCRELEASE_DB += iocRelease.db
 # Install Database to support reading the status of the autosave package:
 DB_INSTALLS += $(AUTOSAVE)/db/save_restoreStatus.db
 
+# Install Database to support reading the status of the seq package:
+DB_INSTALLS += $(SEQ)/db/devSeqCar.db
+
 # Install Database for tprTrigger module
 DB_INSTALLS += $(TPRTRIGGER)/db/tprTrig.db
 DB_INSTALLS += $(TPRTRIGGER)/db/tprDeviceNamePV.db

--- a/l2MpsLNApp/src/Makefile
+++ b/l2MpsLNApp/src/Makefile
@@ -55,6 +55,7 @@ l2MpsLN_DBD += tprPatternAsynDriver.dbd
 l2MpsLN_DBD += bsaCore.dbd
 l2MpsLN_DBD += bsa.dbd
 l2MpsLN_DBD += iocAdmin.dbd
+l2MpsLN_DBD += devSeqCar.dbd
 
 # Add all the support libraries needed by this IOC
 l2MpsLN_LIBS += devIocStats
@@ -68,6 +69,7 @@ l2MpsLN_LIBS += tprPattern
 l2MpsLN_LIBS += tprTrigger
 l2MpsLN_LIBS += BsaCore
 l2MpsLN_LIBS += asyn
+l2MpsLN_LIBS += seqCar seq pv
 
 # Link QSRV (pvAccess Server) if available
 ifdef EPICS_QSRV_MAJOR_VERSION


### PR DESCRIPTION
* Upgrade iocAdmin to version R3.1.16-1.3.0 to deal with timezone PV problem
  * Add seq version R2.2.4-1.2 to RELEASE. Load devSeqCar.dbd and lib devSeqCar seq pv 
      in the src/Makefile to load the devSeqCar.db file for Accelerator network screens
  * Change the macro for autosave from ${L2MPS_PREFIX} to ${IOC_NAME} to conform with
      Accelerator Network common screens.  Changed in link_node.cmd and application_node.cmd
  * Comment in TPR Pattern load in application_node.cmd - this was a mistake in R3-6-0
  * Add sioc-b084-mp03 to run on shm-b084-hp04 slot 2 on cpu-b084-hp03 - BLEN/BCM test stand