### PR TITLE
EEDSW-43

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 Release notes for the SLAC LCLS-II HPS MPS Link Node
 
 ## Releases:
-* __l2MpsLN-R4-5-1__: 2023-08-01 jmock
+* __l2MpsLN-R4-5-1__: 2024-03-08 jmock
   * Fix FLNK bug in Reg3BitsRW.template - RBV PV needs to link to CALC PV
     but it was linking to set PV
   * Adjust mitigation_config.yaml in iocBoot/sioc-sps-mp02 so that RTM_DOUT permits

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,12 @@
 Release notes for the SLAC LCLS-II HPS MPS Link Node
 
 ## Releases:
+* __l2MpsLN-R4-5-1__: 2023-08-01 jmock
+  * Fix FLNK bug in Reg3BitsRW.template - RBV PV needs to link to CALC PV
+    but it was linking to set PV
+  * Adjust mitigation_config.yaml in iocBoot/sioc-sps-mp02 so that RTM_DOUT permits
+    2 and 3 listen to destination 5 (LESA) instead of destination 4 (SXR)
+
 * __l2MpsLN-R4-5-0__: 2023-08-01 jmock
   * Adjust modeManagerLN.db to turn off NC Core when in SC Mode
     * This happens as part of mode switching and is driven by

--- a/iocBoot/sioc-sps-mp02/mitigation_config.yaml
+++ b/iocBoot/sioc-sps-mp02/mitigation_config.yaml
@@ -6,5 +6,5 @@
                 - mpsConfig: !<value> 0x0
                 - mpsRtmDest[0]: !<value> 0x4
                 - mpsRtmDest[1]: !<value> 0x4
-                - mpsRtmDest[2]: !<value> 0x4
-                - mpsRtmDest[3]: !<value> 0x4
+                - mpsRtmDest[2]: !<value> 0x5
+                - mpsRtmDest[3]: !<value> 0x5

--- a/l2MpsLNApp/Db/Reg3BitsRW.template
+++ b/l2MpsLNApp/Db/Reg3BitsRW.template
@@ -47,7 +47,7 @@ record(mbbi,    "$(P):$(R)_RBV") {
     field(FVST, "$(FVST)")
     field(SXST, "$(SXST)")
     field(SVST, "$(SVST)")
-    field(FLNK, "$(P):$(R)")
+    field(FLNK, "$(P):$(R)_CALC")
 }
 record(calc,    "$(P):$(R)_CALC") {
     field(DESC, "$(DESC)")


### PR DESCRIPTION
  * Fix FLNK bug in Reg3BitsRW.template - RBV PV needs to link to CALC PV
    but it was linking to set PV (EEDSW-43)
  * Adjust mitigation_config.yaml in iocBoot/sioc-sps-mp02 so that RTM_DOUT permits
    2 and 3 listen to destination 5 (LESA) instead of destination 4 (SXR) (EEDSW-41)